### PR TITLE
Removing custom tags

### DIFF
--- a/pipeline-CI.yml
+++ b/pipeline-CI.yml
@@ -20,9 +20,6 @@ steps:
     command: buildAndPush
     Dockerfile: Microsoft.OneWeek.Hack.Microids.IoTDevice/Dockerfile
     containerRegistry: 'Azure CR'
-    tags: |
-      $(Date:yyyyMMdd)$(Rev:.r)
-      $(Build.BuildId)
 
 - task: Docker@2
   displayName: Build and Push Restful IoT Device Image
@@ -31,9 +28,6 @@ steps:
     command: buildAndPush
     Dockerfile: Microsoft.OneWeek.Hack.Microids.IoTDevice.Metadata.Restful/Dockerfile
     containerRegistry: 'Azure CR'
-    tags: |
-      $(Date:yyyyMMdd)$(Rev:.r)
-      $(Build.BuildId)
     
 - task: Docker@2
   displayName: Build and Push Message Router Image
@@ -42,6 +36,3 @@ steps:
     command: buildAndPush
     Dockerfile: Microsoft.OneWeek.Hack.Microids.MessageRouter/Dockerfile
     containerRegistry: 'Azure CR'
-    tags: |
-      $(Date:yyyyMMdd)$(Rev:.r)
-      $(Build.BuildId)


### PR DESCRIPTION
Custom tags don't properly get evaluated in the pipeline, so they are causing an error.